### PR TITLE
Fix: Global fixes to the module slider

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -489,6 +489,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.14.4-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.4-x86_64-linux)
       racc (~> 1.4)
     oauth (1.1.0)
@@ -767,6 +769,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -789,4 +792,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.3.5
+   2.4.19

--- a/app/cells/decidim/slider/admin/administrable_content_block/show.erb
+++ b/app/cells/decidim/slider/admin/administrable_content_block/show.erb
@@ -1,6 +1,6 @@
 <li draggable="true" data-content-block-id="<%= model.id %>">
   <div class="draggable-content">
-    <%= t(public_name_key) %>
+    <%= translated_model_name.blank? ? t(public_name_key) : translated_model_name %>
     <div>
       <% if model.persisted? %>
         <% if has_settings? %>

--- a/app/cells/decidim/slider/admin/administrable_content_block_cell.rb
+++ b/app/cells/decidim/slider/admin/administrable_content_block_cell.rb
@@ -22,6 +22,10 @@ module Decidim
         def decidim_admin_slider
           Decidim::Slider::AdminEngine.routes.url_helpers
         end
+
+        def translated_model_name
+          translated_attribute(model.settings.title)
+        end
       end
     end
   end

--- a/app/commands/decidim/slider/admin/create_content_block.rb
+++ b/app/commands/decidim/slider/admin/create_content_block.rb
@@ -27,8 +27,8 @@ module Decidim
         def call
           create_content_block
           broadcast(:ok)
-          rescue StandardError
-            broadcast(:invalid)
+        rescue StandardError
+          broadcast(:invalid)
         end
 
         private

--- a/app/commands/decidim/slider/admin/create_content_block.rb
+++ b/app/commands/decidim/slider/admin/create_content_block.rb
@@ -27,8 +27,8 @@ module Decidim
         def call
           create_content_block
           broadcast(:ok)
-          # rescue StandardError
-          #   broadcast(:invalid)
+          rescue StandardError
+            broadcast(:invalid)
         end
 
         private

--- a/app/commands/decidim/slider/admin/reorder_content_blocks.rb
+++ b/app/commands/decidim/slider/admin/reorder_content_blocks.rb
@@ -12,13 +12,19 @@ module Decidim
             hash.update(id => index + 1)
           end
 
+          error = nil
+
           data.each do |id, weight|
             content_block = collection.find_by(id: id)
             content_block.update!(weight: weight) if content_block.present?
 
             next unless content_block.errors.any?
 
-            flash[:error] = content_block.errors.full_messages.join(", ")
+            error = content_block.errors.full_messages.join(", ")
+          end
+
+          if error.present?
+            flash[:error] = error
           end
         end
       end

--- a/app/commands/decidim/slider/admin/reorder_content_blocks.rb
+++ b/app/commands/decidim/slider/admin/reorder_content_blocks.rb
@@ -11,7 +11,7 @@ module Decidim
           reorder_steps
           broadcast(:ok)
         rescue StandardError
-          broadcast(:invalid, "Error while reordering content blocks")
+          broadcast(:invalid, t("decidim.content_blocks.update.global_error"))
         end
 
         private

--- a/app/commands/decidim/slider/admin/reorder_content_blocks.rb
+++ b/app/commands/decidim/slider/admin/reorder_content_blocks.rb
@@ -15,6 +15,10 @@ module Decidim
           data.each do |id, weight|
             content_block = collection.find_by(id: id)
             content_block.update!(weight: weight) if content_block.present?
+
+            next unless content_block.errors.any?
+
+            flash[:error] = content_block.errors.full_messages.join(", ")
           end
         end
       end

--- a/app/commands/decidim/slider/admin/reorder_content_blocks.rb
+++ b/app/commands/decidim/slider/admin/reorder_content_blocks.rb
@@ -32,7 +32,6 @@ module Decidim
             error = content_block.errors.full_messages.join(", ")
             title = translated_attribute(content_block.settings.title).presence || content_block.manifest_name
             error = t("decidim.content_blocks.update.error", title: title, error: error)
-
           end
 
           if error.present?

--- a/app/commands/decidim/slider/admin/reorder_content_blocks.rb
+++ b/app/commands/decidim/slider/admin/reorder_content_blocks.rb
@@ -5,6 +5,15 @@ module Decidim
     module Admin
       # TODO: Remove when upgrading to Decidim 0.28
       class ReorderContentBlocks < Decidim::Admin::ReorderContentBlocks
+        def call
+          return broadcast(:invalid) if order.blank?
+
+          reorder_steps
+          broadcast(:ok)
+        rescue StandardError
+          broadcast(:invalid, "Error while reordering content blocks")
+        end
+
         private
 
         def set_new_weights
@@ -21,11 +30,21 @@ module Decidim
             next unless content_block.errors.any?
 
             error = content_block.errors.full_messages.join(", ")
+            title = translated_attribute(content_block.settings.title).presence || content_block.manifest_name
+            error = t("decidim.content_blocks.update.error", title: title, error: error)
+
           end
 
           if error.present?
             flash[:error] = error
+            raise StandardError, error
           end
+        end
+
+        def translated_attribute(attribute)
+          return unless attribute.is_a?(Hash)
+
+          attribute[I18n.locale] || attribute.values.first
         end
       end
     end

--- a/app/commands/decidim/slider/admin/update_content_block.rb
+++ b/app/commands/decidim/slider/admin/update_content_block.rb
@@ -34,7 +34,6 @@ module Decidim
           return broadcast(:invalid) unless images_valid
 
           broadcast(:ok, content_block)
-
         rescue StandardError
           broadcast(:invalid)
         end

--- a/app/commands/decidim/slider/admin/update_content_block.rb
+++ b/app/commands/decidim/slider/admin/update_content_block.rb
@@ -5,6 +5,39 @@ module Decidim
     module Admin
       # TODO: Remove when upgrading to Decidim 0.28
       class UpdateContentBlock < Decidim::Admin::UpdateContentBlock
+        def call
+          images_valid = true
+
+          transaction do
+            update_content_block_settings
+
+            # Saving the images will cause the image file validations to run
+            # according to their uploader settings and the organization settings.
+            # The content block validation will fail in case there are processing
+            # errors on the image files.
+            #
+            # NOTE:
+            # The images can be only stored correctly if the content block is
+            # already persisted. This is not the case e.g. when creating a new
+            # newsletter which uses the content blocks through newsletter
+            # templates. This is why this needs to happen after the initial
+            # `content_block.save!` call.
+            update_content_block_images
+
+            # The save method needs to be called another time in order to store
+            # the image information.
+            content_block.save!
+
+            images_valid = false unless content_block.valid?
+          end
+
+          return broadcast(:invalid) unless images_valid
+
+          broadcast(:ok, content_block)
+
+        rescue StandardError
+          broadcast(:invalid)
+        end
       end
     end
   end

--- a/app/controllers/decidim/slider/admin/tabs_controller.rb
+++ b/app/controllers/decidim/slider/admin/tabs_controller.rb
@@ -6,7 +6,7 @@ module Decidim
       class TabsController < Decidim::Admin::ApplicationController
         layout "decidim/admin/settings"
 
-        helper_method :content_block_create_success_text, :content_block_create_error_text
+        helper_method :content_block_create_success_text, :content_block_create_error_text, :content_block_edit_success_text, :content_block_edit_error_text, :content_block_destroy_success_text, :content_block_destroy_error_text
         before_action :patch_organization
 
         # uncomment me when upgrading to Decidim 0.28
@@ -60,9 +60,11 @@ module Decidim
 
           UpdateContentBlock.call(@form, content_block, content_block_scope) do
             on(:ok) do
+              flash[:success] = content_block_edit_success_text
               redirect_to edit_resource_landing_page_path
             end
             on(:invalid) do
+              flash[:error] = content_block_edit_error_text
               edit # Sets the model to the view so that it can render the form
               render "edit"
             end
@@ -89,6 +91,14 @@ module Decidim
 
         def content_block_destroy_error_text
           t("slider.tabs.destroy_error", scope: "decidim.admin")
+        end
+
+        def content_block_edit_success_text
+          t("slider.tabs.edit_success", scope: "decidim.admin")
+        end
+
+        def content_block_edit_error_text
+          t("slider.tabs.edit_error", scope: "decidim.admin")
         end
 
         def patch_organization

--- a/app/controllers/decidim/slider/admin/tabs_controller.rb
+++ b/app/controllers/decidim/slider/admin/tabs_controller.rb
@@ -6,7 +6,9 @@ module Decidim
       class TabsController < Decidim::Admin::ApplicationController
         layout "decidim/admin/settings"
 
-        helper_method :content_block_create_success_text, :content_block_create_error_text, :content_block_edit_success_text, :content_block_edit_error_text, :content_block_destroy_success_text, :content_block_destroy_error_text
+        helper_method :content_block_create_success_text, :content_block_create_error_text,
+                      :content_block_edit_success_text, :content_block_edit_error_text,
+                      :content_block_destroy_success_text, :content_block_destroy_error_text
         before_action :patch_organization
 
         # uncomment me when upgrading to Decidim 0.28

--- a/app/views/decidim/slider/admin/slider/index.html.erb
+++ b/app/views/decidim/slider/admin/slider/index.html.erb
@@ -58,6 +58,8 @@
             url: document.querySelector(".js-list-actives").dataset.sortUrl,
             contentType: "application/json",
             data: JSON.stringify({ ids_order: activeBlocksId })
-        });
+        }).catch(function (error) {
+            window.location.reload();
+        })
     })
 </script>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,7 +7,7 @@ en:
           active_blocks_title: Active Blocks
           add: Add Tabs
           destroy_confirmation: Are you sure you want to delete this tab?
-          inactive_blocks_title: Active Blocks
+          inactive_blocks_title: Inactive Blocks
           title: The title for Tabs
         tabs:
           create_error: There was an error creating the tab
@@ -18,6 +18,9 @@ en:
           success_message: The tab was successfully created
           edit_success: The tab was successfully edited
     content_blocks:
+      update:
+        error: "An error occurred while updating '%{title}': %{error}"
+
       slider:
         admin_menu: Homepage Slider
         name: Slider

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,9 +12,11 @@ en:
         tabs:
           create_error: There was an error creating the tab
           destroy_error: There was an error deleting the tab
+          edit_error: There was an error editing the tab
           destroy_message: The tab was successfully deleted
           save: Save
           success_message: The tab was successfully created
+          edit_success: The tab was successfully edited
     content_blocks:
       slider:
         admin_menu: Homepage Slider

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,7 +20,7 @@ en:
     content_blocks:
       update:
         error: "An error occurred while updating '%{title}': %{error}"
-
+        global_error: "An error occurred while reordering the blocks"
       slider:
         admin_menu: Homepage Slider
         name: Slider


### PR DESCRIPTION
## Description 🎩 

This PR has been made to fix somme issues that we may have identified on the module slider :

- While modifying the max size of an asset, he could block any reordering of active components while a component had an error in it,
- We couldn't modify this errored component as the verification was made before any changes and blocked it completely.
- We couldn't clearly identify the component that was producing error because it is identified with "Image" or "Videos" and no by its optional name (that was totally understandable but made things unclear sometimes)

## How to test this PR 🔧 

- Generate your app
- Log as an admin
- Go to the back office
- Go to settings
- Go to homepage then set the max file size to 10mo
- Go to the module settings below and create few components
- Upload an image < 10mo but above 3mo for one of them (we don't really need an exact size)
- Return to the homepage settings and set limit to 1 mo
- Check that you can do everything you want without be blocked except and that you're well notified if you get some errors